### PR TITLE
Supplementing transcription hint

### DIFF
--- a/app.js
+++ b/app.js
@@ -244,6 +244,7 @@ const startAudioFork = (channelId, userId) => {
           initialMessage.language = language == 'auto' ? language : language.slice(0,2);
           initialMessage.partialUtterances = partialUtterances;
           initialMessage.minUtteranceLength = minUtteranceLength;
+          initialMessage.transcription_hint = config.get(provider + '.hint');
         }
 
         if (!socketStatus[channelId]) {

--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -50,7 +50,7 @@ gladia:
   startMessage: '{"x_gladia_key": "", "sample_rate": 0, "bit_depth": 16, "model_type": "fast", "endpointing": 300 }'
   endMessage: '{}'
   # Provide a custom vocabulary to the model to improve accuracy of transcribing context specific words, technical terms, names, etc.
-  # If empty, this argument is ignored. Please be aware that this field has a character limit of 600. 
+  # If empty, this field is ignored. Please be aware of a character limit of 600. 
   hint: ''
   server: ws://localhost:8777
   proxy:

--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -49,7 +49,7 @@ vosk:
 gladia:
   startMessage: '{"x_gladia_key": "", "sample_rate": 0, "bit_depth": 16, "model_type": "fast", "endpointing": 300 }'
   endMessage: '{}'
-  # Provides a custom vocabulary to the model to improve accuracy of transcribing context specific words, technical terms, names, etc.
+  # Provide a custom vocabulary to the model to improve accuracy of transcribing context specific words, technical terms, names, etc.
   # If empty, this argument is ignored. Please be aware that this field has a character limit of 600. 
   hint: ''
   server: ws://localhost:8777

--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -49,6 +49,7 @@ vosk:
 gladia:
   startMessage: '{"x_gladia_key": "", "sample_rate": 0, "bit_depth": 16, "model_type": "fast", "endpointing": 300 }'
   endMessage: '{}'
+  hint: ''
   server: ws://localhost:8777
   proxy:
     enabled: true

--- a/config/default.example.yml
+++ b/config/default.example.yml
@@ -49,6 +49,8 @@ vosk:
 gladia:
   startMessage: '{"x_gladia_key": "", "sample_rate": 0, "bit_depth": 16, "model_type": "fast", "endpointing": 300 }'
   endMessage: '{}'
+  # Provides a custom vocabulary to the model to improve accuracy of transcribing context specific words, technical terms, names, etc.
+  # If empty, this argument is ignored. Please be aware that this field has a character limit of 600. 
   hint: ''
   server: ws://localhost:8777
   proxy:


### PR DESCRIPTION
This PR is to supplement the transcription_hint parameter to the Gladia API. 
https://docs.gladia.io/chapters/speech-to-text-api/pages/live-speech-recognition

Testing it in Japanese, I realised that the effect is limited, but saw some improvement. We may need more testing in western languages.

When the hint field in the config file is left blank, the API simply ignore it. Adding words in this field starts the hinting.